### PR TITLE
add boostrap action var

### DIFF
--- a/aws_datalake/modules/emr/main.tf
+++ b/aws_datalake/modules/emr/main.tf
@@ -17,7 +17,11 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   service_role           = var.iam_emr_service_role
   autoscaling_role       = var.iam_emr_autoscaling_role
   security_configuration = var.security_configuration
-  bootstrap_action { var.bootstrap_action }
+  bootstrap_action {
+  	path = var.bootstrap_action.path
+  	name = var.bootstrap_action.name
+  	args = var.bootstrap_action.args
+  }
 
   master_instance_group {
     instance_type = var.master_instance_type

--- a/aws_datalake/modules/emr/main.tf
+++ b/aws_datalake/modules/emr/main.tf
@@ -17,6 +17,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   service_role           = var.iam_emr_service_role
   autoscaling_role       = var.iam_emr_autoscaling_role
   security_configuration = var.security_configuration
+  bootstrap_action       = var.bootstrap_action
 
   master_instance_group {
     instance_type = var.master_instance_type

--- a/aws_datalake/modules/emr/main.tf
+++ b/aws_datalake/modules/emr/main.tf
@@ -17,10 +17,15 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   service_role           = var.iam_emr_service_role
   autoscaling_role       = var.iam_emr_autoscaling_role
   security_configuration = var.security_configuration
-  bootstrap_action {
-  	path = var.bootstrap_action.path
-  	name = var.bootstrap_action.name
-  	args = var.bootstrap_action.args
+  
+  dynamic "bootstrap_action" {
+    for_each = var.bootstrap_action
+
+    content {
+      args = try(bootstrap_action.value.args, null)
+      name = bootstrap_action.value.name
+      path = bootstrap_action.value.path
+    }
   }
 
   master_instance_group {

--- a/aws_datalake/modules/emr/main.tf
+++ b/aws_datalake/modules/emr/main.tf
@@ -17,7 +17,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   service_role           = var.iam_emr_service_role
   autoscaling_role       = var.iam_emr_autoscaling_role
   security_configuration = var.security_configuration
-  bootstrap_action       = var.bootstrap_action
+  bootstrap_action { var.bootstrap_action }
 
   master_instance_group {
     instance_type = var.master_instance_type

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -103,7 +103,7 @@ variable "task_instance_max_count" {
 
 variable "bootstrap_action" {
   description = "Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
-  type        = list(map(string))
+  type        = map(string)
   default     = []
 }
 

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -101,6 +101,11 @@ variable "task_instance_max_count" {
   default     = "4"
 }
 
+variable "bootstrap_action" {
+  description = "Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
+  type        = list(object)
+}
+
 locals {
   tags = merge(tomap({"vendor" = "segment"}), var.tags)
 }

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -103,7 +103,7 @@ variable "task_instance_max_count" {
 
 variable "bootstrap_action" {
   description = "Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
-  type        = map(any)
+  type        = object({path = string, name = string, args = list(string)})
   default     = {}
 }
 

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -104,7 +104,7 @@ variable "task_instance_max_count" {
 variable "bootstrap_action" {
   description = "Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
   type        = map(string)
-  default     = []
+  default     = {}
 }
 
 locals {

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -103,7 +103,7 @@ variable "task_instance_max_count" {
 
 variable "bootstrap_action" {
   description = "Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
-  type        = list(object)
+  type        = list(map(string))
 }
 
 locals {

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -103,7 +103,7 @@ variable "task_instance_max_count" {
 
 variable "bootstrap_action" {
   description = "Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
-  type        = map(string)
+  type        = map(any)
   default     = {}
 }
 

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -104,6 +104,7 @@ variable "task_instance_max_count" {
 variable "bootstrap_action" {
   description = "Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
   type        = list(map(string))
+  default     = []
 }
 
 locals {

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -103,7 +103,7 @@ variable "task_instance_max_count" {
 
 variable "bootstrap_action" {
   description = "Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
-  type        = object({path = string, name = string, args = list(string)})
+  type        = any
   default     = {}
 }
 

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -363,40 +363,15 @@ resource "aws_iam_policy" "segment_emr_instance_profile_policy" {
 EOF
 }
 
-resource "aws_iam_policy" "custom_emr_instance_profile_policy" {
-  name = "CalmEMRInstanceProfilePolicy${var.suffix}"
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ssm:DescribeParameters"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ssm:GetParameter"
-
-            ],
-            "Resource": "arn:aws:ssm:us-east-1:083265760884:parameter/data-dev/us-east-1/segment-data-lake/*"
-        }
-    ]
-}
-EOF
-}
-
 resource "aws_iam_role_policy_attachment" "segment_emr_instance_profile_policy_attachment" {
   role = aws_iam_role.segment_emr_instance_profile_role.name
   policy_arn = aws_iam_policy.segment_emr_instance_profile_policy.arn
 }
 
 resource "aws_iam_role_policy_attachment" "segment_emr_instance_profile_policy_custom_attachment" {
+  count = var.custom_emr_instance_profile_policy_arn ? 1 : 0
   role = aws_iam_role.segment_emr_instance_profile_role.name
-  policy_arn = aws_iam_policy.custom_emr_instance_profile_policy.arn
+  policy_arn = var.custom_emr_instance_profile_policy_arn
 }
 
 # IAM Role for EMR Autoscaling role

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -289,9 +289,8 @@ resource "aws_iam_instance_profile" "segment_emr_instance_profile" {
   role = aws_iam_role.segment_emr_instance_profile_role.name
 }
 
-resource "aws_iam_role_policy" "segment_emr_instance_profile_policy" {
+resource "aws_aim_policy" "segment_emr_instance_profile_policy" {
   name = "SegmentEMRInstanceProfilePolicy${var.suffix}"
-  role = aws_iam_role.segment_emr_instance_profile_role.id
 
   policy = <<EOF
 {
@@ -362,6 +361,11 @@ resource "aws_iam_role_policy" "segment_emr_instance_profile_policy" {
 ]
 }
 EOF
+}
+
+resource "aws_aim_role_policy_attachment" "segment_emr_instance_profile_policy_attachment" {
+  role = segment_emr_instance_profile_role.name
+  policy_arn = segment_emr_instance_profile_policy.arn
 }
 
 # IAM Role for EMR Autoscaling role

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -379,7 +379,7 @@ resource "aws_iam_policy" "custom_emr_instance_profile_policy" {
         {
             "Effect": "Allow",
             "Action": [
-                "ssm:GetParameters"
+                "ssm:GetParameter"
 
             ],
             "Resource": "arn:aws:ssm:us-east-1:083265760884:parameter/data-dev/us-east-1/segment-data-lake/*"

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -289,7 +289,7 @@ resource "aws_iam_instance_profile" "segment_emr_instance_profile" {
   role = aws_iam_role.segment_emr_instance_profile_role.name
 }
 
-resource "aws_aim_policy" "segment_emr_instance_profile_policy" {
+resource "aws_iam_policy" "segment_emr_instance_profile_policy" {
   name = "SegmentEMRInstanceProfilePolicy${var.suffix}"
 
   policy = <<EOF
@@ -388,12 +388,12 @@ resource "aws_iam_policy" "custom_emr_instance_profile_policy" {
 EOF
 }
 
-resource "aws_aim_role_policy_attachment" "segment_emr_instance_profile_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "segment_emr_instance_profile_policy_attachment" {
   role = segment_emr_instance_profile_role.name
   policy_arn = segment_emr_instance_profile_policy.arn
 }
 
-resource "aws_aim_role_policy_attachment" "segment_emr_instance_profile_policy_custom_attachment" {
+resource "aws_iam_role_policy_attachment" "segment_emr_instance_profile_policy_custom_attachment" {
   role = segment_emr_instance_profile_role.name
   policy_arn = custom_emr_instance_profile_policy.arn
 }

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -380,8 +380,9 @@ resource "aws_iam_policy" "custom_emr_instance_profile_policy" {
             "Effect": "Allow",
             "Action": [
                 "ssm:GetParameters"
+
             ],
-            "Resource": "arn:aws:ssm:us-east-1:083265760884:parameter/data-dev/us-east-1/segment-data-lake"
+            "Resource": "arn:aws:ssm:us-east-1:083265760884:parameter/data-dev/us-east-1/segment-data-lake/*"
         }
     ]
 }

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -363,9 +363,39 @@ resource "aws_aim_policy" "segment_emr_instance_profile_policy" {
 EOF
 }
 
+resource "aws_iam_policy" "custom_emr_instance_profile_policy" {
+  name = "CalmEMRInstanceProfilePolicy${var.suffix}"
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:DescribeParameters"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameters"
+            ],
+            "Resource": "arn:aws:ssm:us-east-1:083265760884:parameter/data-dev/datalakes"
+        }
+    ]
+}
+EOF
+}
+
 resource "aws_aim_role_policy_attachment" "segment_emr_instance_profile_policy_attachment" {
   role = segment_emr_instance_profile_role.name
   policy_arn = segment_emr_instance_profile_policy.arn
+}
+
+resource "aws_aim_role_policy_attachment" "segment_emr_instance_profile_policy_custom_attachment" {
+  role = segment_emr_instance_profile_role.name
+  policy_arn = custom_emr_instance_profile_policy.arn
 }
 
 # IAM Role for EMR Autoscaling role
@@ -392,6 +422,7 @@ EOF
 
   tags = local.tags
 }
+
 
 resource "aws_iam_role_policy" "segmnet_emr_autoscaling_policy" {
   name = "SegmentEMRAutoscalingPolicy${var.suffix}"

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -369,7 +369,7 @@ resource "aws_iam_role_policy_attachment" "segment_emr_instance_profile_policy_a
 }
 
 resource "aws_iam_role_policy_attachment" "segment_emr_instance_profile_policy_custom_attachment" {
-  count = var.custom_emr_instance_profile_policy_arn ? 1 : 0
+  count = var.attach_custom_emr_isntance_profile_policy ? 1 : 0
   role = aws_iam_role.segment_emr_instance_profile_role.name
   policy_arn = var.custom_emr_instance_profile_policy_arn
 }

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -389,13 +389,13 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "segment_emr_instance_profile_policy_attachment" {
-  role = segment_emr_instance_profile_role.name
-  policy_arn = segment_emr_instance_profile_policy.arn
+  role = aws_iam_role.segment_emr_instance_profile_role.name
+  policy_arn = aws_iam_policy.segment_emr_instance_profile_policy.arn
 }
 
 resource "aws_iam_role_policy_attachment" "segment_emr_instance_profile_policy_custom_attachment" {
-  role = segment_emr_instance_profile_role.name
-  policy_arn = custom_emr_instance_profile_policy.arn
+  role = aws_iam_role.segment_emr_instance_profile_role.name
+  policy_arn = aws_iam_policy.custom_emr_instance_profile_policy.arn
 }
 
 # IAM Role for EMR Autoscaling role

--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -381,7 +381,7 @@ resource "aws_iam_policy" "custom_emr_instance_profile_policy" {
             "Action": [
                 "ssm:GetParameters"
             ],
-            "Resource": "arn:aws:ssm:us-east-1:083265760884:parameter/data-dev/datalakes"
+            "Resource": "arn:aws:ssm:us-east-1:083265760884:parameter/data-dev/us-east-1/segment-data-lake"
         }
     ]
 }

--- a/aws_datalake/modules/iam/variables.tf
+++ b/aws_datalake/modules/iam/variables.tf
@@ -46,6 +46,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "custom_emr_instance_profile_policy_arn" {
+  description = "ARN of a IAM policy. This policy will be attached to the instance profile role"
+  type        = string
+  default     = ""
+}
+
 locals {
   tags = merge(tomap({"vendor" = "segment"}), var.tags)
 }

--- a/aws_datalake/modules/iam/variables.tf
+++ b/aws_datalake/modules/iam/variables.tf
@@ -53,7 +53,7 @@ variable "custom_emr_instance_profile_policy_arn" {
 }
 
 variable "attach_custom_emr_isntance_profile_policy" {
-  decription = "boolean flag to use the above policy arn"
+  description = "boolean flag to use the above policy arn"
   type       = bool
   default    = false
 }

--- a/aws_datalake/modules/iam/variables.tf
+++ b/aws_datalake/modules/iam/variables.tf
@@ -52,6 +52,12 @@ variable "custom_emr_instance_profile_policy_arn" {
   default     = ""
 }
 
+variable "attach_custom_emr_isntance_profile_policy" {
+  decription = "boolean flag to use the above policy arn"
+  type       = bool
+  default    = false
+}
+
 locals {
   tags = merge(tomap({"vendor" = "segment"}), var.tags)
 }


### PR DESCRIPTION
Comparing to `emr-security-configuration` since that's what I branched from. Fine to merge this elsewhere, too. 

Separately, we're prodding Segment support to roll in our PRs so we can get off this fork.